### PR TITLE
[3694][FIX] stock_picking_accounting_date

### DIFF
--- a/stock_picking_accounting_date/__manifest__.py
+++ b/stock_picking_accounting_date/__manifest__.py
@@ -1,8 +1,8 @@
-# Copyright 2023 Quartile Limited
+# Copyright 2023-2024 Quartile Limited
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 {
     "name": "Stock Picking Accounting Date",
-    "version": "16.0.1.0.0",
+    "version": "16.0.1.0.1",
     "author": "Quartile Limited, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/stock-logistics-warehouse",
     "category": "Stock",

--- a/stock_picking_accounting_date/models/stock_move.py
+++ b/stock_picking_accounting_date/models/stock_move.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Quartile Limited
+# Copyright 2023-2024 Quartile Limited
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import api, fields, models
@@ -14,10 +14,20 @@ class StockMove(models.Model):
 
     @api.depends("date", "accounting_date")
     def _compute_accounting_date(self):
-        for line in self:
-            line.accounting_date = fields.Datetime.context_timestamp(self, line.date)
-            if line.picking_id.accounting_date:
-                line.accounting_date = line.picking_id.accounting_date
+        # 'force_period_date' context is assigned when user sets accounting date in
+        # inventory adjustment
+        force_period_date = self._context.get("force_period_date")
+        if force_period_date:
+            for line in self:
+                line.accounting_date = force_period_date
+        else:
+            for line in self:
+                if line.picking_id.accounting_date:
+                    line.accounting_date = line.picking_id.accounting_date
+                    continue
+                line.accounting_date = fields.Datetime.context_timestamp(
+                    self, line.date
+                )
 
     def _prepare_account_move_vals(
         self,

--- a/stock_picking_accounting_date/models/stock_move.py
+++ b/stock_picking_accounting_date/models/stock_move.py
@@ -18,16 +18,13 @@ class StockMove(models.Model):
         # inventory adjustment
         force_period_date = self._context.get("force_period_date")
         if force_period_date:
-            for line in self:
-                line.accounting_date = force_period_date
+            self.write({"accounting_date": force_period_date})
         else:
-            for line in self:
-                if line.picking_id.accounting_date:
-                    line.accounting_date = line.picking_id.accounting_date
+            for rec in self:
+                if rec.picking_id.accounting_date:
+                    rec.accounting_date = rec.picking_id.accounting_date
                     continue
-                line.accounting_date = fields.Datetime.context_timestamp(
-                    self, line.date
-                )
+                rec.accounting_date = fields.Datetime.context_timestamp(self, rec.date)
 
     def _prepare_account_move_vals(
         self,


### PR DESCRIPTION
[3694](https://www.quartile.co/web#id=3694&menu_id=505&cids=3&action=1457&model=project.task&view_type=form)

Before this commit, accounting date set in inventory adjustments would be nullified as the date of the account move would be overriden by the accounting date field of the originating stock move, which was missing consideration on the force_period_date context.

This commit fixes the issue by respecting the context value in assigning the accounting date in stock moves.
