### PR TITLE
[4364][FIX] template_content_swapper

### DIFF
--- a/template_content_swapper/models/template_content_mapping.py
+++ b/template_content_swapper/models/template_content_mapping.py
@@ -22,6 +22,7 @@ class TemplateContentMapping(models.Model):
         compute="_compute_template_id",
         store=True,
         readonly=False,
+        precompute=True,
         help="Select the main template of the report / frontend page to be modified.",
     )
     lang = fields.Selection(


### PR DESCRIPTION
[4364](https://www.quartile.co/web#id=4364&menu_id=505&cids=3&action=1457&model=project.task&view_type=form)

This commit fixes the issue of Odoo throwing a validation error on template_id field when trying to create a new content mapping record with report_id.

![image](https://github.com/qrtl/thc-oca/assets/7766939/fd70602a-b95b-442b-ada4-f2ea236f3e45)