### PR TITLE
[5119][FIX] stock_move_value

### DIFF
--- a/stock_move_value/models/stock_move.py
+++ b/stock_move_value/models/stock_move.py
@@ -40,7 +40,7 @@ class StockMove(models.Model):
     def _compute_move_value(self):
         for move in self:
             # There can be multiple svls per move in case landed costs are entered
-            move.move_value = sum(move.stock_valuation_layer_ids.mapped("value"))
+            move.move_value = sum(move.sudo().stock_valuation_layer_ids.mapped("value"))
 
     def _action_done(self, cancel_backorder=False):
         origin_values = defaultdict(dict)
@@ -60,7 +60,7 @@ class StockMove(models.Model):
             }
         moves = super()._action_done(cancel_backorder)
         for move in moves:
-            move.move_value = sum(move.stock_valuation_layer_ids.mapped("value"))
+            move.move_value = sum(move.sudo().stock_valuation_layer_ids.mapped("value"))
             if not move._is_out() or not move.origin_returned_move_id:
                 continue
             move.move_origin_value = (


### PR DESCRIPTION
[5119](https://www.quartile.co/web#cids=3&menu_id=505&action=1457&model=project.task&view_type=form&id=5119)

Fixed the issue where users other than Inventory/Administrator encountered access errors with stock.valuation.layer during Internal Transfers